### PR TITLE
Fix doc and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 David Purdum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ This is list of cases that convert\_case supports.  Some cases are simply aliase
 | UpperFlat | MYVARIABLENAME |
 | Random | MY vaRiabLe nAME |
 | PseudoRandom | mY VaRiAblE nAMe |
+
+## License
+
+Licensed under [MIT License](./LICENSE).

--- a/src/case.rs
+++ b/src/case.rs
@@ -147,7 +147,7 @@ pub enum Case {
     /// let new = "My variable NAME".to_case(Case::Random);
     /// ```
     /// `new` could be "My vaRIAbLE nAme" for example.
-    #[cfg(feature = "random")]
+    #[cfg(any(doc, feature = "random"))]
     Random,
 
     /// Pseudo-random case strings are delimited by spaces and characters are randomly
@@ -159,7 +159,7 @@ pub enum Case {
     /// let new = "My variable NAME".to_case(Case::Random);
     /// ```
     /// `new` could be "mY vArIAblE NamE" for example.
-    #[cfg(feature = "random")]
+    #[cfg(any(doc, feature = "random"))]
     PseudoRandom,
 }
 


### PR DESCRIPTION
Hey!

I added the missing `LICENSE` file (`MIT License`, under your name), and updated `Case` to make `rustdoc` generate the documentation for `Random` and `PseudoRandom` even when the `random` feature isn't turned on (so that it is displayed on docs.rs).

Cheers!