### PR TITLE
Add without_boundaries to Casing trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,11 +246,25 @@ pub trait Casing<T: AsRef<str>> {
     /// ```
     fn with_boundaries(&self, bs: &[Boundary]) -> StateConverter<T>;
 
+    /// Creates a `StateConverter` struct initialized without the boundaries
+    /// provided.
+    /// ```
+    /// use convert_case::{Boundary, Case, Casing};
+    ///
+    /// assert_eq!(
+    ///     "2d_transformation",
+    ///     "2dTransformation"
+    ///         .without_boundaries(&Boundary::digits())
+    ///         .to_case(Case::Snake)
+    /// );
+    /// ```
+    fn without_boundaries(&self, bs: &[Boundary]) -> StateConverter<T>;
+
     /// Determines if `self` is of the given case.  This is done simply by applying
     /// the conversion and seeing if the result is the same.
     /// ```
     /// use convert_case::{Case, Casing};
-    /// 
+    ///
     /// assert!( "kebab-case-string".is_case(Case::Kebab));
     /// assert!( "Train-Case-String".is_case(Case::Train));
     ///
@@ -270,6 +284,10 @@ where
 
     fn with_boundaries(&self, bs: &[Boundary]) -> StateConverter<T> {
         StateConverter::new(self).with_boundaries(bs)
+    }
+
+    fn without_boundaries(&self, bs: &[Boundary]) -> StateConverter<T> {
+        StateConverter::new(self).without_boundaries(bs)
     }
 
     fn from_case(&self, case: Case) -> StateConverter<T> {


### PR DESCRIPTION
# Intro

Add `without_boundaries` to the `Casing` trait to allow the below usage:

```
"2dTransFormation".without_boundaries(&Boundary::digits()).to_case(Case::Snake)
```

# Motivation

There is a `with_boundaries` method in both `Casing` and `StateConverter`. But we can only use `without_boundaries` with `StateConverter`. It is convenient to have `without_boundaries` in `Casing`.

# Worry

- Haven't fully tested this. Though the code in the doc seems working well.
- Adding a method to the `Casing` trait is a breaking change. (IMO)