### PR TITLE
Ensure `Hash` is consistent with `PartialEq` for `Boundary`

### DIFF
--- a/src/boundary.rs
+++ b/src/boundary.rs
@@ -1,6 +1,7 @@
 use unicode_segmentation::UnicodeSegmentation;
 
 use alloc::vec::Vec;
+use core::hash::{Hash, Hasher};
 
 fn grapheme_is_digit(c: &&str) -> bool {
     c.chars().all(|c| c.is_ascii_digit())
@@ -41,7 +42,7 @@ fn grapheme_is_lowercase(c: &&str) -> bool {
 ///     .to_case(Case::Title);
 /// assert_eq!("7empest By Tool", conv.convert("7empest byTool"));
 /// ```
-#[derive(Debug, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Eq, Clone, Copy)]
 pub struct Boundary {
     /// A unique name used for comparison.
     pub name: &'static str,
@@ -61,6 +62,12 @@ pub struct Boundary {
 impl PartialEq for Boundary {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
+    }
+}
+
+impl Hash for Boundary {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
     }
 }
 


### PR DESCRIPTION
With the Rust hash trait, if `PartialEq` says that `a == b`, then `hash(a)` *must* be equal to `hash(b)` - see [here](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq) in the docs.

Previously, `PartialEq` used `name` for comparisons, but the `Hash` derive used every field and so that invariant wasn't upheld. This PR fixes that.