### PR TITLE
Fix boundary check when when multiple matchers should match

### DIFF
--- a/src/boundary.rs
+++ b/src/boundary.rs
@@ -452,7 +452,6 @@ where
                 // todo clean this up a bit
                 words.push(&s[last_boundary_end..boundary_byte_start]);
                 last_boundary_end = boundary_byte_end;
-                break;
             }
         }
     }


### PR DESCRIPTION
Allow additional boundary checks after a match.

## Motivation

I was adding two custom boundary _matchers_ that trigger in the same place, but add the boundary at different points.
The specific need is to place boundaries _around_ something.

The `break` in the loop makes the second boundary _matcher_ to be skipped.

## Notes

After the change, all the tests still pass.